### PR TITLE
#162147777 Add admin edit record status page

### DIFF
--- a/UI/admin_edit.html
+++ b/UI/admin_edit.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content ="width=device-width">
+	<meta name="description" content="Affordable">
+	<meta name="keywords" content="web design">
+	<meta name="author" content="koech">
+    <title>iReporter | Admin Status Edit</title>
+	<link rel="stylesheet" href="./css/style.css">
+</head>
+
+<body>
+	<body>
+	<header>
+		<div class="container">
+			<div id="branding">
+				<h1>iReporter</h1>
+			</div>
+			<div>
+				<a href="admin_profile.html">Back to dashboard</a>
+			</div>
+		</div>
+			
+	</header>
+
+
+    
+</head>
+<body>
+		<section class="container">
+			<h3>Edit a record status using its id below</h3>
+
+			
+
+			<div>
+					<p>
+               			<p><label >Unique record ID</label></p>
+               			<p><input type="text" name="title" placeholder=" Type existing Record Id"></p>
+         			</p>
+					
+					<div class="form-control form-input">
+                		<label for="status">Status</label>
+                			<br>
+                		<select name="status" id="status">
+                    		<option value="under_investigation">Under investigation</option>
+                    		<option value="rejected">Rejected</option>
+                    		<option value="resolved">Resolved</option>
+                		</select>
+
+            		</div>
+         			
+              
+          	</div>
+
+      
+				
+				
+  				<section class="container">
+					<div class="sub"> 
+                    	<p><button class="sub">Update</button></p>
+                	</div>
+                </section>
+         
+
+
+
+
+</body>
+</html>


### PR DESCRIPTION
What does this PR do?
This PR adds an admin edit redflag/intervention record page that gives an admin user ability to edit user record status.
Description of task to be completed?
Create an admin edit record status page that allows an admin  user to modify an existing record status
How should this be manually tested?
after cloning the repository open the UI folder and open the admin_edit.html file using a browser preferably chrome.
What are the relevant pivotal tracker stories?
#162147777
Relevant screenshot?
![screenshot from 2018-11-25 18-12-13](https://user-images.githubusercontent.com/22771559/48980719-c9454980-f0dd-11e8-85c6-58547938b4f0.png)

