### PR TITLE
#162183191 Add admin list records page

### DIFF
--- a/UI/admin_list.html
+++ b/UI/admin_list.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content ="width=device-width">
+	<meta name="description" content="Affordable">
+	<meta name="keywords" content="web design">
+	<meta name="author" content="koech">
+    <title>iReporter | List of Records</title>
+	<link rel="stylesheet" href="./css/style.css">
+</head>
+
+<body>
+	<body>
+	<header>
+		<div class="container">
+			<div id="branding">
+				<h1>iReporter</h1>
+			</div>
+			<div>
+				<a href="admin_profile.html">Back to dashboard</a>
+			</div>
+		</div>
+			
+	</header>
+
+
+    
+</head>
+<body>
+<section class="container">
+<h2>Redflag/Intervention Records for all users</h2>
+
+<table>
+  <tr>
+    <th>Id</th>
+    <th>Type</th>
+    <th>Title</th>
+    <th>Location</th>
+    <th>Description</th>
+    <th>Status</th>
+  </tr>
+  <tr>
+    <td>#456</td>
+    <td>Redflag</td>
+    <td>Bribe</td>
+    <td>Maseno</td>
+    <td>A teacher receiving bribe from a student</td>
+    <td>Rejected</td> 
+  </tr>
+  <tr>
+    <td>#457</td>
+    <td>Intervention</td>
+    <td>Pothole</td>
+    <td>Maseno drive,Maseno</td>
+    <td>Huge potholes on the road</td>
+    <td>Resolved</td>
+  </tr>
+</table>
+</section>
+
+
+
+
+</body>
+</html>


### PR DESCRIPTION
### What does this PR do?
This PR adds an admin list record page that allows an admin user to view all user redflag/intervention records.
### Description of task to be completed?
Create an admin record list  page that allows an admin user to view all user records.
### How should this be manually tested?
after cloning the repository open the UI folder and open the admin_list.html file using a browser preferably chrome.
### What are the relevant pivotal tracker stories?
#162183191
### Relevant screenshot?
![screenshot from 2018-11-25 18-44-14](https://user-images.githubusercontent.com/22771559/48981086-3824a180-f0e2-11e8-81d1-c6b7c1bb55a9.png)


